### PR TITLE
Label JSX template file added to src/components

### DIFF
--- a/src/components/03-labels/label.jsx
+++ b/src/components/03-labels/label.jsx
@@ -1,0 +1,26 @@
+/**
+ * JSX Label Component Attributes
+ * @function Label
+ * @param {Object} config The configuration object for label attributes
+ * @property {string} config.class - The classes inherited from the USWDS CSS files. The default class is `usa-label` and additions can be appended.
+ * @property {string} config.for - The for attribute is supposed to match the 'id' attribute of a labelable form element that exists within the same document as the <label> element.
+ *  The first element in the document with an id matching the value of the for attribute is the labeled control for this label element, if it is a labelable element.
+ * If it is not labelable then the for attribute has no effect.
+ * If there are other elements which also match the id value, later in the document, they are not considered.
+ * @property {string} config.innerText - The text to be displayed for the label
+ * @example
+ * const config = {
+ *     class: "",
+ *     for: "submit"
+ *     innerText: "Click here to submit your form: "
+ *   }
+ * @returns {HTMLLabelElement} The JSX HTML Label
+ */
+
+exports.Label = function (config) {
+  return (
+    <label class={`usa-label ${config.class}`} for={config.for}>
+      {config.innerText}
+    </label>
+  );
+};

--- a/src/components/03-labels/label.jsx
+++ b/src/components/03-labels/label.jsx
@@ -14,7 +14,11 @@
  *     for: "submit"
  *     innerText: "Click here to submit your form: "
  *   }
- * @returns {HTMLLabelElement} The JSX HTML Label
+ * Label(config);
+ * @returns {HTMLLabelElement} The HTML Label
+ * <label class=`usa-label` for="submit">
+ *    Click here to submit your form: 
+ * </label>
  */
 
 exports.Label = function (config) {


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact designsystem.digital.gov’s look, feel, or functionality, please open a pull request on the uswds-site repo (https://github.com/uswds/uswds-site).

-->

## Description

This pull requests adds the .jsx template file for creating `<label>` components inside of _src/components/03-labels_. It follows the same structure as the `<button>` template file, so its returns an HTML `<label>` and has its attributes documented with JSDoc comments. Closes [nyc-cto/USWDS-generator/issues/59](https://github.com/nyc-cto/USWDS-generator/issues/59)