### PR TITLE
Alert JSX template file added to src/components

### DIFF
--- a/src/components/05-alerts/alert.jsx
+++ b/src/components/05-alerts/alert.jsx
@@ -3,31 +3,44 @@
  * @function Alert
  * @param {Object} config - The configuration object for alert attributes.
  * @property {string} config.class - The classes inherited from the USWDS CSS files. The default class is `usa-alert` and additions can be appended.
+ * @property {string} [config.bodyClass] - String to specify additional classes for the body of the alert. (Optional)
+ * @property {string} [config.headerClass] - String to specify additional classes for the header of the alert. (Optional)
+ * @property {string} [config.textClass] - String to specify additional classes for the text in the alert. (Optional)
  * @property {string} [config.headerText] - The text to be displayed as the header for the alert. (Optional)
  * @property {string} config.innerText - The actual alert message text to be displayed in the body of the Alert element.
  * @example
  * const config = {
  *      class: "usa-alert--success",
- *      headerText: "Success status"
+ *      bodyClass: "",
+ *      headerClass: "",
+ *      textClass: "",
+ *      headerText: "Success status",
  *      innerText: "Your submission was successfull! You should recieve an email from us shortly."
  * }
+ * Alert(config)
  * @example -
  *  const config = {
  *      class: "usa-alert--info usa-alert--slim",
- *      headerText: null
+ *      bodyClass: "",
+ *      headerClass: "",
+ *      textClass: "",
+ *      headerText: "",
  *      innerText: "Note: Some aspects of the site are a work in progress and may have some bugs. We appreciate your patience."
  * }
+ * Alert(config)
  * @returns {HTMLDivElement} The HTML Alert element
  */
 
 exports.Alert = function (config) {
   return (
     <div class={`usa-alert ${config.class}`}>
-      <div class="usa-alert__body">
+      <div class={`usa-alert__body ${config.bodyClass}`}>
         {config.headerText && (
-          <h3 class="usa-alert__heading">{config.headerText}</h3>
+          <h3 class={`usa-alert__heading ${config.headerClass}`}>
+            {config.headerText}
+          </h3>
         )}
-        <p class="usa-alert__text">{config.innerText}</p>
+        <p class={`usa-alert__text ${config.textClass}`}>{config.innerText}</p>
       </div>
     </div>
   );

--- a/src/components/05-alerts/alert.jsx
+++ b/src/components/05-alerts/alert.jsx
@@ -1,0 +1,52 @@
+/**
+ * JSX Alert Component Attributes
+ * @function Alert
+ * @param {Object} config - The configuration object for alert attributes
+ * @property {string} config.class - The classes inherited from the USWDS CSS files. The default class is `usa-alert` and additions can be appended.
+ * @property {string} config.headerText - The text to be displayed as the header for the alert, if its supposed to have one.
+ * @property {string} config.innerText - The actual alert message text to be displayed in the body of the Alert element
+ * @example
+ * const config = {
+ *      class: "usa-alert--success",
+ *      headerText: "Success status"
+ *      innerText: "Your submission was successfull! You should recieve an email from us shortly."
+ * }
+ * @example - When using "usa-alert--slim" or "usa-alert--no-icon" there is not supposed to be a header
+ *  const config = {
+ *      class: "usa-alert--info usa-alert--slim",
+ *      headerText: null
+ *      innerText: "Note: Some aspects of the site are a work in progress and may have some bugs. We appreciate your patience."
+ * }
+ * @returns {HTMLDivElement} The JSX HTML Alert element
+ */
+
+exports.Alert = function (config) {
+  theHeader = alertHeader(config);
+  return (
+    <div class={`usa-alert ${config.class}`}>
+      ::before
+      <div class="usa-alert__body">
+        {theHeader}
+        <p class="usa-alert__text">{config.innerText}</p>
+      </div>
+    </div>
+  );
+};
+/**
+ * @function alertHeader
+ * @param {Object} config - The configuration object for alert attributes
+ * @property {string} config.headerText - The text to be displayed as the header for the alert, if its supposed to have one.
+ * @returns {HTMLHeadElement} - The header that may or may not be in the alert element
+ */
+let alertHeader = function (config) {
+  if (
+    //these 2 CSS classes aren't supposed to have a header
+    config.class.includes("usa-alert--slim") ||
+    config.class.includes("usa-alert--no-icon")
+  ) {
+    return;
+  } else {
+    //any other class can have a header
+    return <h3 class="usa-alert__heading">{config.headerText}</h3>;
+  }
+};

--- a/src/components/05-alerts/alert.jsx
+++ b/src/components/05-alerts/alert.jsx
@@ -3,7 +3,7 @@
  * @function Alert
  * @param {Object} config - The configuration object for alert attributes.
  * @property {string} config.class - The classes inherited from the USWDS CSS files. The default class is `usa-alert` and additions can be appended.
- * @property {string} config.headerText - The text to be displayed as the header for the alert.
+ * @property {string} [config.headerText] - The text to be displayed as the header for the alert. (Optional)
  * @property {string} config.innerText - The actual alert message text to be displayed in the body of the Alert element.
  * @example
  * const config = {
@@ -11,7 +11,7 @@
  *      headerText: "Success status"
  *      innerText: "Your submission was successfull! You should recieve an email from us shortly."
  * }
- * @example - When using "usa-alert--slim" or "usa-alert--no-icon" there is not supposed to be a header
+ * @example -
  *  const config = {
  *      class: "usa-alert--info usa-alert--slim",
  *      headerText: null
@@ -20,10 +20,9 @@
  * @returns {HTMLDivElement} The HTML Alert element
  */
 
-exports.Alerts = function (config) {
+exports.Alert = function (config) {
   return (
     <div class={`usa-alert ${config.class}`}>
-      ::before
       <div class="usa-alert__body">
         {config.headerText && (
           <h3 class="usa-alert__heading">{config.headerText}</h3>

--- a/src/components/05-alerts/alerts.jsx
+++ b/src/components/05-alerts/alerts.jsx
@@ -17,11 +17,21 @@
  *      headerText: null
  *      innerText: "Note: Some aspects of the site are a work in progress and may have some bugs. We appreciate your patience."
  * }
- * @returns {HTMLDivElement} The JSX HTML Alert element
+ * @returns {HTMLDivElement} The HTML Alert element
  */
 
-exports.Alert = function (config) {
-  theHeader = alertHeader(config);
+exports.Alerts = function (config) {
+  let theHeader;
+  if (
+    //these 2 CSS classes aren't supposed to have a header
+    config.class.includes("usa-alert--slim") ||
+    config.class.includes("usa-alert--no-icon")
+  ) {
+    theHeader = null;
+  } else {
+    //any other class can have a header
+    theHeader = <h3 class="usa-alert__heading">{config.headerText}</h3>;
+  }
   return (
     <div class={`usa-alert ${config.class}`}>
       ::before
@@ -31,22 +41,4 @@ exports.Alert = function (config) {
       </div>
     </div>
   );
-};
-/**
- * @function alertHeader
- * @param {Object} config - The configuration object for alert attributes
- * @property {string} config.headerText - The text to be displayed as the header for the alert, if its supposed to have one.
- * @returns {HTMLHeadElement} - The header that may or may not be in the alert element
- */
-let alertHeader = function (config) {
-  if (
-    //these 2 CSS classes aren't supposed to have a header
-    config.class.includes("usa-alert--slim") ||
-    config.class.includes("usa-alert--no-icon")
-  ) {
-    return;
-  } else {
-    //any other class can have a header
-    return <h3 class="usa-alert__heading">{config.headerText}</h3>;
-  }
 };

--- a/src/components/05-alerts/alerts.jsx
+++ b/src/components/05-alerts/alerts.jsx
@@ -1,10 +1,10 @@
 /**
  * JSX Alert Component Attributes
  * @function Alert
- * @param {Object} config - The configuration object for alert attributes
+ * @param {Object} config - The configuration object for alert attributes.
  * @property {string} config.class - The classes inherited from the USWDS CSS files. The default class is `usa-alert` and additions can be appended.
- * @property {string} config.headerText - The text to be displayed as the header for the alert, if its supposed to have one.
- * @property {string} config.innerText - The actual alert message text to be displayed in the body of the Alert element
+ * @property {string} config.headerText - The text to be displayed as the header for the alert.
+ * @property {string} config.innerText - The actual alert message text to be displayed in the body of the Alert element.
  * @example
  * const config = {
  *      class: "usa-alert--success",
@@ -21,22 +21,13 @@
  */
 
 exports.Alerts = function (config) {
-  let theHeader;
-  if (
-    //these 2 CSS classes aren't supposed to have a header
-    config.class.includes("usa-alert--slim") ||
-    config.class.includes("usa-alert--no-icon")
-  ) {
-    theHeader = null;
-  } else {
-    //any other class can have a header
-    theHeader = <h3 class="usa-alert__heading">{config.headerText}</h3>;
-  }
   return (
     <div class={`usa-alert ${config.class}`}>
       ::before
       <div class="usa-alert__body">
-        {theHeader}
+        {config.headerText && (
+          <h3 class="usa-alert__heading">{config.headerText}</h3>
+        )}
         <p class="usa-alert__text">{config.innerText}</p>
       </div>
     </div>


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact designsystem.digital.gov’s look, feel, or functionality, please open a pull request on the uswds-site repo (https://github.com/uswds/uswds-site).

-->

## Description

This pull request adds a .jsx template file for creating **Alert** components inside of _src/components/05-alerts_. It is slightly more complex than previous HTML elements because it is a `<div>` element with some other HTML elements nested inside of it.  One of those is the `<h3>` header which may or may not be included depending on the "class" attribute. I added a function to handle returning either the `<h3>` or nothing in the file. I'm open to any critiques on this way of going about generating this compnent 👍  Closes [nyc-cto/USWDS-generator/issues/61](https://github.com/nyc-cto/USWDS-generator/issues/61)