### PR TITLE
Tooltip JSX template file added to src/components

### DIFF
--- a/src/components/12-tooltip/tooltip.jsx
+++ b/src/components/12-tooltip/tooltip.jsx
@@ -1,0 +1,40 @@
+/**
+ * @function Tooltip
+ * @param {Object} config - Configuration object for tooltip components
+ * @property {string} config.class - string that specifies class for the tooltip
+ * @property {string} config.id - ID number in string form for the tooltip
+ * @property {boolean} config.hidden - Boolean property that if set to "true" removes that element and all of its children from the accessibility tree
+ * @property {string} config.innerText - string that is the actual text to be displayed in the tooltip
+ * @example
+ * const config={
+ *      class: "usa-tooltip__body--top"
+ *      id: "867530"
+ *      hidden: true
+ *      innerText: "This text will be displayed on top"
+ * }
+ * Tooltip(config)
+ * @example
+ * const config={
+ *      class: "usa-tooltip__body--right"
+ *      id: "013370"
+ *      hidden: true
+ *      innerText: "This text will be displayed on to the right"
+ * }
+ * Tooltip(config)
+ * @returns {HTMLSpanElement} - The HTML code for the tooltip
+ */
+
+exports.Tooltip = function (config) {
+  return (
+    <span class="usa-tooltip">
+      <span
+        class={`usa-tooltip__body ${config.class}`}
+        id={`tooltip-${config.id}`}
+        role="tooltip"
+        aria-hidden={config.hidden}
+      >
+        {config.innerText}
+      </span>
+    </span>
+  );
+};


### PR DESCRIPTION
<!-- Please feel free to remove whatever sections/lines in this aren’t relevant.

Use the title line as the title of your pull request, then delete these lines.

## Title line template: [Title]: Brief description

Website: For pull requests that impact designsystem.digital.gov’s look, feel, or functionality, please open a pull request on the uswds-site repo (https://github.com/uswds/uswds-site).

-->

## Description

This Pull Request adds a .jsx template file for the tooltip component. It is set up the same as the other with JSDoc comments above it explaining how it works and examples on how to use it. It returns HTML code just as like our other templates. Closes [nyc-cto/USWDS-generator/issues/73](https://github.com/nyc-cto/USWDS-generator/issues/73)